### PR TITLE
Change elm-platform submodule URL to https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "elm-platform"]
 	path = elm-platform
-	url = git@github.com:elm-lang/elm-platform.git
+	url = https://github.com/elm-lang/elm-platform.git


### PR DESCRIPTION
To prevent unnecessarily loading ssh keys
