### PR TITLE
Use short options for ln in elmenv-install

### DIFF
--- a/libexec/elmenv-install
+++ b/libexec/elmenv-install
@@ -213,7 +213,7 @@ if [ "$STATUS" == "0" ]; then
   cd "$BIN_ROOT"
 
   for file in "$INSTALLERS_OUTPUT"/*; do
-    ln --symbolic --force "$file"
+    ln -sf "$file"
   done
 
   cd "$ELMENV_ROOT"


### PR DESCRIPTION
It sounds crazy, but `ln` on OS X doesn't support long options!

```
➜ ~ ln --symbolic foo bar
ln: illegal option -- -
usage: ln [-Ffhinsv] source_file [target_file]
       ln [-Ffhinsv] source_file ... target_dir
       link source_file target_file
```
