### PR TITLE
Add elm---version cmd

### DIFF
--- a/libexec/elmenv---version
+++ b/libexec/elmenv---version
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Summary: Display the version of elmenv
+#
+# Displays the current revision from git, if available.
+
+set -e
+[ -n "$ELMENV_DEBUG" ] && set -x
+
+if cd "$ELMENV_ROOT" 2>/dev/null; then
+  git_revision="$(git rev-parse HEAD 2>/dev/null || true)"
+fi
+
+echo "elmenv ${git_revision}"


### PR DESCRIPTION
Just shows the git revision since there is no concept of elmenv versions right now. Fixes two calls to `elm---version` in `libexec/elmenv`.
