### PR TITLE
Elm v0.16 support added.

### DIFF
--- a/libexec/elmenv-install
+++ b/libexec/elmenv-install
@@ -198,7 +198,7 @@ cleanup() {
 trap cleanup SIGINT
 
 INSTALLERS_ROOT="$ELMENV_ROOT/elm-platform/installers"
-INSTALLERS_OUTPUT="$ELMENV_ROOT/elm-platform/installers/Elm-Platform/$VERSION_NAME/bin"
+INSTALLERS_OUTPUT="$ELMENV_ROOT/elm-platform/installers/Elm-Platform/$VERSION_NAME/.cabal-sandbox/bin"
 
 # Invoke `elmenv` and record the exit status in $STATUS.
 STATUS=0

--- a/libexec/elmenv-rehash
+++ b/libexec/elmenv-rehash
@@ -82,7 +82,7 @@ remove_outdated_shims() {
 # List basenames of executables for every Elm version
 list_executable_names() {
   local file
-  for file in "$ELMENV_ROOT"/elm-platform/installers/Elm-Platform/*/bin/*; do
+  for file in "$ELMENV_ROOT"/elm-platform/installers/Elm-Platform/*/*; do
     echo "${file##*/}"
   done
 }


### PR DESCRIPTION
Work on Mac OS X 10.10.5, ghc 7.10.1, cabal 1.22.4.0
Addresses issue #7 
